### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ As you can see, we leave the default implementation as open as possible, this wa
 ## Styles
 We expose a few css clases that you can edit, otherwise, you can use our ugly css default.
 
-* o_day_picker: the calendar container
+* o_day-picker: the calendar container
 * i_day-picker-header: weeks headers
 * i_day-picker-body: calendar body
 * e_day-picker-buttons: prev and next month


### PR DESCRIPTION
Hi, I found a typo in README.md

o_day-picker (x) -> o_day-picker (o)